### PR TITLE
Macro ClearSelection

### DIFF
--- a/addedFeature/ClearSelection.txsMacro
+++ b/addedFeature/ClearSelection.txsMacro
@@ -1,0 +1,16 @@
+{
+    "abbrev": "",
+    "description": [
+        "Clears a selection, so you don't need to move the cursor"
+    ],
+    "formatVersion": 1,
+    "menu": "",
+    "name": "Clear Selection",
+    "shortcut": "Alt+Q",
+    "tag": [
+        "%SCRIPT",
+        "/* V1.0 2022-06-22 by octaeder */",
+        "cursor.clearSelection();"
+    ],
+    "trigger": ""
+}


### PR DESCRIPTION
Usefull in combination with macro "Transpose Cursor and Anchor Positions". Other usecase: Select "text", ctrl+b creates \textbf{__text__} with text selected (bold print here). Now overwrite closing brace (option Overwrite Closing Bracket Following a Placeholder). But since "text" is selected, we can't enter the brace. The macro clears the selection and we can overwrite the brace. Otherwise we would have to do something like cursor left and cursor right. s. texstudio-org/texstudio#599