### PR TITLE
Make Zotero Picker compatible again

### DIFF
--- a/zotero-picker/zoteroPicker.txsMacro
+++ b/zotero-picker/zoteroPicker.txsMacro
@@ -1,16 +1,16 @@
 {
-    "name" : "Launch Zotero Picker",
-    "formatVersion": 1,
-    "tag" : [
-        "%SCRIPT",
-        "var url = 'http://127.0.0.1:23119/better-bibtex/cayw??format=biblatex&command=autocite&texstudio=true&minimize=true';",
-        "system('curl -s -A \"TeXstudio\" ' + url);"
+    "name": "Launch Zotero Picker",
+    "formatVersion": 2,
+    "tag": [
+        "var url = \"http://127.0.0.1:23119/better-bibtex/cayw??format=biblatex&command=autocite&texstudio=true&minimize=true\"",
+        "system(\"curl -s \" + url)"
     ],
-    "description" : [
-        "This macro lets you CAYW (Cite As You Write). Among other advantages, it lets you type anything which is contained in the references to retrieve them (and not only their citekeys as currently needed by the TeXstudio auto-completion). It needs Zotero (https://www.zotero.org/, to be open when used) and its (properly configured) Better Bibtex add-on (https://github.com/retorquere/zotero-better-bibtex), plus curl (https://curl.haxx.se/) which is available on numerous OSes. The following video lets you see this macro in action: https://youtu.be/Whn9Mk-JwL0. Enjoy!"
+    "type": "Script",
+    "description": [
+        " \"This macro lets you CAYW (Cite As You Write). Among other advantages, it lets you type anything which is contained in the references to retrieve them (and not only their citekeys as currently needed by the TeXstudio auto-completion). It needs Zotero (https://www.zotero.org/, to be open when used) and its (properly configured) Better Bibtex add-on (https://github.com/retorquere/zotero-better-bibtex), plus curl (https://curl.haxx.se/) which is available on numerous OSes. The following video lets you see this macro in action: https://youtu.be/Whn9Mk-JwL0. Enjoy!\""
     ],
-    "abbrev" : "",
-    "trigger" : "aaa",
-    "menu" : "Zotero Picker",
-    "shortcut" : ""
+    "abbrev": "",
+    "trigger": "",
+    "menu": "",
+    "shortcut": ""
 }


### PR DESCRIPTION
I updated the zotero script. I wasn't able to import it anymore and recreated it.
I removed the shortcut "aaa" and menu part as well as they have no use.
PS: Whats the menu part about anyways? It didn'T seem to affect anything and wasn'T able to configure it in the UI either.